### PR TITLE
Fix error message for fetching supported languages

### DIFF
--- a/frontend/src/widgets/code-quiz-card/model/useSupportedProgrammingLanguages.ts
+++ b/frontend/src/widgets/code-quiz-card/model/useSupportedProgrammingLanguages.ts
@@ -17,7 +17,7 @@ export const useSupportedProgrammingLanguages = () => {
         setSupportedProgrammingLanguages(data);
       } catch (error) {
         setSupportedProgrammingLanguages([]);
-        console.error("Failed to fetch supported difficulty levels", error);
+        console.error("Failed to fetch supported programming languages", error);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- fix typo in `useSupportedProgrammingLanguages` error message

## Testing
- `npx lefthook run pre-commit` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68754316a54c83289dfb6a807bb6d56d