### PR TITLE
feat(frontend): persist quiz preferences

### DIFF
--- a/frontend/src/shared/lib/store/quiz.ts
+++ b/frontend/src/shared/lib/store/quiz.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import type { QuizResponse } from "@/shared/api";
 
 type QuizStore = {
@@ -11,12 +12,24 @@ type QuizStore = {
   setProgrammingLanguage: (lang: string) => void;
 };
 
-export const useQuizStore = create<QuizStore>(set => ({
-  quiz: null,
-  difficultyLevel: "ADVANCED",
-  programmingLanguage: "JAVA",
+export const useQuizStore = create<QuizStore>()(
+  persist(
+    set => ({
+      quiz: null,
+      difficultyLevel: "ADVANCED",
+      programmingLanguage: "JAVA",
 
-  setQuiz: quiz => set({ quiz }),
-  setDifficultyLevel: difficultyLevel => set({ difficultyLevel }),
-  setProgrammingLanguage: programmingLanguage => set({ programmingLanguage })
-}));
+      setQuiz: quiz => set({ quiz }),
+      setDifficultyLevel: difficultyLevel => set({ difficultyLevel }),
+      setProgrammingLanguage: programmingLanguage =>
+        set({ programmingLanguage })
+    }),
+    {
+      name: "quiz-store",
+      partialize: state => ({
+        programmingLanguage: state.programmingLanguage,
+        difficultyLevel: state.difficultyLevel
+      })
+    }
+  )
+);


### PR DESCRIPTION
## Summary
- persist programming language and difficulty level selections in quiz store

## Testing
- `npm run biome`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a51449e7388328b5e632d58af34beb